### PR TITLE
Added several changes to video downloading functions

### DIFF
--- a/src/twitter_video_assist_server.js
+++ b/src/twitter_video_assist_server.js
@@ -29,7 +29,7 @@ function processVideoSource({
         if (!!tweetId) {
             processBlobVideo(tweetId, readerableFilename, token)
         }
-    } else if (videoSource.includes('ext_tw_video')) {
+    } else if (videoSource.includes('ext_tw_video') || videoSource.includes('amplify_video')) {
         downloadMp4Video(videoSource, readerableFilename)
     } else {
         processGifVideo(videoSource, readerableFilename)


### PR DESCRIPTION
Based on Flkalas' version 3.2 (which uses extractGraphQlMp4Video), I added the ability to pull tweets that are replies. If a tweet video (reply) cannot be pulled from the home timeline page, the code will now open a new window consisting of the tweet's individual timeline page (user then click the download button again on that individual tweet timeline).

Furthermore, I implemented the ability to pull videos and pictures simultaneously. The code now gathers a videoIndex to locate different videos properly from the grid containers.

The code is very rudimentary, pending future changes.