### PR TITLE
Ignore downloads not by this extension

### DIFF
--- a/src/twitter_video_downloader.js
+++ b/src/twitter_video_downloader.js
@@ -2,7 +2,7 @@ let readableNameList = {}
 const fileNameRegex = /([\w,\s-.]+\.[A-Za-z]{2,4}$)/
 
 function chromeDownloadRenamer(item, suggest) {
-    if (!item.byExtensionId && item.byExtensionId !== chrome.runtime.id) {
+    if (!item.byExtensionId || item.byExtensionId !== chrome.runtime.id) {
         return
     }
 


### PR DESCRIPTION
This seems to be a bug which will end up renaming download files that are not downloaded by this extension.